### PR TITLE
Add check to avoid panic

### DIFF
--- a/chat/app/controllers/websocket.go
+++ b/chat/app/controllers/websocket.go
@@ -18,6 +18,11 @@ func (c WebSocket) Room(user string) revel.Result {
 }
 
 func (c WebSocket) RoomSocket(user string, ws *websocket.Conn) revel.Result {
+	// Make sure the websocket is valid.
+	if ws == nil {
+		return nil	
+	}
+	
 	// Join the room.
 	subscription := chatroom.Subscribe()
 	defer subscription.Cancel()


### PR DESCRIPTION
Without the `if ws == nil {}` check, a panic can easily occur.